### PR TITLE
Add tasks list widget to the Tasks tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,3 @@
-
 import './App.css';
 import BottomNavbar from './components/BottomNavbar';
 import {
@@ -11,21 +10,38 @@ import Home from './pages/Home';
 import Calendar from './pages/Calendar';
 import Tasks from './pages/Tasks';
 import TaskScheduler from './pages/TaskScheduler';
+import { MuiThemeProvider, createMuiTheme, makeStyles } from "@material-ui/core/styles";
+
 
 function App() {
   let history = useHistory();
 
+  const useStyles = makeStyles((theme) => ({
+    root: {
+        height: "100%",
+        backgroundColor: theme.palette.background.default,
+    },
+  }));
+  const classes = useStyles();
+  const theme = createMuiTheme({
+    palette: {
+        type: "dark",
+    },
+  });
+
   return (
-    <div className="App">
-      <BrowserRouter history={history} >
-        <Switch>
-          <Route path="/home" component={Home} />
-          <Route path="/calendar" component={Calendar} />
-          <Route path="/tasks" component={Tasks} />
-          <Route path="/scheduler" component={TaskScheduler} />
-        </Switch>
-        <BottomNavbar value={"home"} />
-      </BrowserRouter>
+    <div className="App" className={classes.root}>
+      <MuiThemeProvider theme={theme}>
+        <BrowserRouter history={history} >
+          <Switch>
+            <Route path="/home" component={Home} />
+            <Route path="/calendar" component={Calendar} />
+            <Route path="/tasks" component={Tasks} />
+            <Route path="/scheduler" component={TaskScheduler} />
+          </Switch>
+          <BottomNavbar value={"home"} />
+        </BrowserRouter>
+      </MuiThemeProvider>
     </div>
   );
 }

--- a/src/components/TaskListItem.js
+++ b/src/components/TaskListItem.js
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Checkbox from '@material-ui/core/Checkbox';
+
+export default function TaskListItem(labelId) {
+    const [checked, setChecked] = useState(false);
+
+    return (
+        <ListItem key={1} 
+                    role={undefined}
+                    dense
+                    button
+                    onClick={() => setChecked(!checked)}
+                    >
+            <ListItemIcon>
+                <Checkbox edge="start"
+                checked={checked}
+                disableRipple
+                inputProps= {{'aria-labelledby': labelId}}/>   
+            </ListItemIcon>
+            <ListItemText id={labelId} primary={`You got work to do!`} />
+        </ListItem>
+    );
+};

--- a/src/components/TaskListItem.js
+++ b/src/components/TaskListItem.js
@@ -3,9 +3,21 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Checkbox from '@material-ui/core/Checkbox';
+import { makeStyles } from '@material-ui/core/styles';
 
-export default function TaskListItem(labelId) {
+const useStyles = makeStyles((theme) => ({
+    CompletedText: {
+        textDecoration: 'line-through',
+        fontStyle: 'italic',
+    },
+    IncompleteText: {
+        fontStyle: 'normal'
+    },
+}));
+
+export default function TaskListItem(props) {
     const [checked, setChecked] = useState(false);
+    const classes = useStyles();
 
     return (
         <ListItem key={1} 
@@ -18,9 +30,12 @@ export default function TaskListItem(labelId) {
                 <Checkbox edge="start"
                 checked={checked}
                 disableRipple
-                inputProps= {{'aria-labelledby': labelId}}/>   
+                inputProps= {{'aria-labelledby': props.labelId}}/>   
             </ListItemIcon>
-            <ListItemText id={labelId} primary={`You got work to do!`} />
+            <ListItemText id={props.labelId} 
+                    primary={props.primaryText}
+                    className={(checked)?classes.CompletedText:classes.IncompleteText} 
+            />
         </ListItem>
     );
 };

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -1,10 +1,6 @@
 import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
-import Checkbox from '@material-ui/core/Checkbox';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
@@ -22,26 +18,22 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-const createNewTaskEntry = (labelId) => {
-    return <ListItem key={1} 
-                role={undefined}
-                dense
-                button
-                >
-        <ListItemIcon>
-            <Checkbox edge="start"
-            checked={false}
-            disableRipple
-            inputProps= {{'aria-labelledby': labelId}}/>   
-        </ListItemIcon>
-        <ListItemText id={labelId} primary={`You got work to do!`} />
-    </ListItem>
-};
 
 export default function Tasks() {
     const classes = useStyles();
     const labelId = `checkbox-list-label-1`;
     const [taskEntryText, setTaskEntryText] = useState('');
+    const createTaskEntry = (title) => {
+        return (<TaskListItem labelId={labelId} primaryText={title} />);
+    };
+
+    const [taskEntries, setTaskEntries] = useState([
+        createTaskEntry("You've got work to do")
+    ]);
+
+    const addTaskEntry = () => {
+        setTaskEntries([...taskEntries, createTaskEntry(taskEntryText)])
+    }
 
     return (
         <div className="App-header">
@@ -56,13 +48,14 @@ export default function Tasks() {
                         variant="contained"
                         className={classes.button}
                         startIcon={<AddIcon />}
+                        onClick={() => addTaskEntry()}
                 >
                     Add
                 </Button>
             </form>
 
             <List className={classes.root}>
-                <TaskListItem labelId={labelId} />
+                { taskEntries }
             </List>
         </div>
         );

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -8,6 +8,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
+import TaskListItem from '../components/TaskListItem';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -61,9 +62,7 @@ export default function Tasks() {
             </form>
 
             <List className={classes.root}>
-                {
-                    createNewTaskEntry(labelId)
-                }
+                <TaskListItem labelId={labelId} />
             </List>
         </div>
         );

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -1,7 +1,70 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Checkbox from '@material-ui/core/Checkbox';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        width: '100%',
+        maxWidth: 360,
+        padding: '10px',
+        backgroundColor: theme.palette.background.default,
+    },
+    NewTaskEntry: {
+        width: '75%',
+    }
+}));
+
+const createNewTaskEntry = (labelId) => {
+    return <ListItem key={1} 
+                role={undefined}
+                dense
+                button
+                >
+        <ListItemIcon>
+            <Checkbox edge="start"
+            checked={false}
+            disableRipple
+            inputProps= {{'aria-labelledby': labelId}}/>   
+        </ListItemIcon>
+        <ListItemText id={labelId} primary={`You got work to do!`} />
+    </ListItem>
+};
+
 export default function Tasks() {
+    const classes = useStyles();
+    const labelId = `checkbox-list-label-1`;
+    const [taskEntryText, setTaskEntryText] = useState('');
+
     return (
         <div className="App-header">
             And some tasks
+            <form className={classes.root}>
+                <TextField label="Enter a new task" 
+                        className={classes.NewTaskEntry}
+                        value={taskEntryText}
+                        onChange={(evt) => setTaskEntryText(evt.target.value) }
+                />
+                <Button color="primary" 
+                        variant="contained"
+                        className={classes.button}
+                        startIcon={<AddIcon />}
+                >
+                    Add
+                </Button>
+            </form>
+
+            <List className={classes.root}>
+                {
+                    createNewTaskEntry(labelId)
+                }
+            </List>
         </div>
-    );
-}
+        );
+    }


### PR DESCRIPTION
# Problem Context
Currently the tasks tab is an empty placeholder.

# Proposed Changes
This PR adds the following changes:
- A basic todo list widget to the Tasks tab.
- Ability to enter new todo items.
- Ability to mark existing items as done.

__NOTE__:  The todo list state is not persistent by design, as we will wire up state persistence in upcoming PRs.

# Meta
| Q             | A                                                                                      |
| ------------- | -------------------------------------------------------------------------------------- |
| Issue Type    | Feature                                             |                                                                                |
| Issues        | Fix #16  |
| Docs Updated | n |
| ADR Updated | n |




